### PR TITLE
Add Calendar Dividend & Earnings scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ from datetime import datetime, timedelta
 timestamp_now = datetime.now().timestamp()
 timestamp_in_7_days = (datetime.now() + timedelta(days=7)).timestamp()
 
-res = calendar.scrape_earnings(scrape_dividends, timestamp_in_7_days, ["america"])
+res = calendar.scrape_dividends(scrape_dividends, timestamp_in_7_days, ["america"])
 ```
 
 ## Changes:

--- a/README.md
+++ b/README.md
@@ -306,7 +306,45 @@ for packet in data_generator:
 {'m': 'qsd', 'p': ['qs_folpuhzgowtu', {'n': 'BINANCE:BTCUSDT', 's': 'ok', 'v': {'volume': 6817.46425, 'lp_time': 1734082521, 'lp': 99957.9, 'chp': -0.05, 'ch': -46.39}}]}
 ```
 
+### 7. Getting Calendar events
 
+#### Scraping Earnings events
+```python
+from tradingview_scraper.symbols.cal import CalendarScraper
+
+calendar_scraper = CalendarScraper()
+
+# Scrape earnings from all markets.
+res = calendar_scraper.scrape_earnings()
+
+
+# Scrape upcoming week earnings from the american market
+from datetime import datetime, timedelta
+
+timestamp_now = datetime.now().timestamp()
+timestamp_in_7_days = (datetime.now() + timedelta(days=7)).timestamp()
+
+res = calendar.scrape_earnings(timestamp_now, timestamp_in_7_days, ["america"])
+```
+
+#### Scraping Dividend events
+```python
+from tradingview_scraper.symbols.cal import CalendarScraper
+
+calendar_scraper = CalendarScraper()
+
+# Scrape dividends from all markets.
+res = calendar_scraper.scrape_dividends()
+
+
+# Scrape upcoming week dividends from the american market
+from datetime import datetime, timedelta
+
+timestamp_now = datetime.now().timestamp()
+timestamp_in_7_days = (datetime.now() + timedelta(days=7)).timestamp()
+
+res = calendar.scrape_earnings(scrape_dividends, timestamp_in_7_days, ["america"])
+```
 
 ## Changes:
 - Release `0.4.0`:  

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ from datetime import datetime, timedelta
 timestamp_now = datetime.now().timestamp()
 timestamp_in_7_days = (datetime.now() + timedelta(days=7)).timestamp()
 
-res = calendar.scrape_earnings(timestamp_now, timestamp_in_7_days, ["america"])
+res = calendar_scraper.scrape_earnings(timestamp_now, timestamp_in_7_days, ["america"])
 ```
 
 #### Scraping Dividend events
@@ -343,7 +343,7 @@ from datetime import datetime, timedelta
 timestamp_now = datetime.now().timestamp()
 timestamp_in_7_days = (datetime.now() + timedelta(days=7)).timestamp()
 
-res = calendar.scrape_dividends(scrape_dividends, timestamp_in_7_days, ["america"])
+res = calendar_scraper.scrape_dividends(timestamp_now, timestamp_in_7_days, ["america"])
 ```
 
 ## Changes:

--- a/tradingview_scraper/symbols/cal.py
+++ b/tradingview_scraper/symbols/cal.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, Union, Optional, List, Dict
 import requests, datetime, json
 
 from tradingview_scraper.symbols.utils import (
@@ -11,15 +11,15 @@ from tradingview_scraper.symbols.utils import (
 class DividendEvent(TypedDict):
     full_symbol: str
     dividend_ex_date_recent: int
-    dividend_ex_date_upcoming: int | None
+    dividend_ex_date_upcoming: Union[int, None]
     logoid: str
     name: str
     description: str
     dividends_yield: float
     dividend_payment_date_recent: int
-    dividend_payment_date_upcoming: int | None
+    dividend_payment_date_upcoming: Union[int, None]
     dividend_amount_recent: float
-    dividend_amount_upcoming: float | None
+    dividend_amount_upcoming: Union[float, None]
     fundamental_currency_code: str
     market: str
 
@@ -30,23 +30,23 @@ class EarningsEvent(TypedDict):
     logoid: str
     name: str
     description: str
-    earnings_per_share_fq: float | None
-    earnings_per_share_forecast_next_fq: float | None
-    eps_surprise_fq: float | None
-    eps_surprise_percent_fq: float | None
-    revenue_fq: float | None
-    revenue_forecast_next_fq: float | None
+    earnings_per_share_fq: Union[float, None]
+    earnings_per_share_forecast_next_fq: Union[float, None]
+    eps_surprise_fq: Union[float, None]
+    eps_surprise_percent_fq: Union[float, None]
+    revenue_fq: Union[float, None]
+    revenue_forecast_next_fq: Union[float, None]
     market_cap_basic: float
     earnings_release_time: int
     earnings_release_next_time: int
-    earnings_per_share_forecast_fq: float | None
-    revenue_forecast_fq: float | None
+    earnings_per_share_forecast_fq: Union[float, None]
+    revenue_forecast_fq: Union[float, None]
     fundamental_currency_code: str
     market: str
     earnings_publication_type_fq: int
     earnings_publication_type_next_fq: int
-    revenue_surprise_fq: float | None
-    revenue_surprise_percent_fq: float | None
+    revenue_surprise_fq: Union[float, None]
+    revenue_surprise_percent_fq: Union[float, None]
 
 
 class CalendarScraper:
@@ -61,10 +61,10 @@ class CalendarScraper:
     def __init__(self, export_result: bool = False, export_type: str = "json"):
         self.export_result: bool = export_result
         self.export_type: str = export_type
-        self.headers: dict[str, str] = {"User-Agent": generate_user_agent()}
+        self.headers: Dict[str, str] = {"User-Agent": generate_user_agent()}
 
     def _export(
-        self, data, symbol: str | None = None, data_category: str | None = None
+        self, data, symbol: Union[str, None] = None, data_category: Union[str, None] = None
     ):
         if self.export_result:
             if self.export_type == "json":
@@ -74,10 +74,10 @@ class CalendarScraper:
 
     def scrape_dividends(
         self,
-        timestamp_from: int | None,
-        timestamp_to: int | None,
-        markets: list[str] | None,
-    ) -> list[DividendEvent]:
+        timestamp_from: Optional[int] = None,
+        timestamp_to: Optional[int] = None,
+        markets: Optional[List[str]] = None,
+    ) -> List[DividendEvent]:
         """
         Scrapes dividends events from the TradingView event calendar.
 
@@ -95,12 +95,12 @@ class CalendarScraper:
         url = "https://scanner.tradingview.com/global/scan?label-product=calendar-dividends"
 
         # By default the timestamps mimick the timestamps used in the web requests
-        if timestamp_from == None:
+        if timestamp_from is None:
             current_date = datetime.datetime.now().timestamp()
             current_date = current_date - (current_date % 86400) - (3 * 86400)
             timestamp_from = int(current_date)
 
-        if timestamp_to == None:
+        if timestamp_to is None:
             current_date = datetime.datetime.now().timestamp()
             current_date = current_date - (current_date % 86400) + (3 * 86400) + 86399
             timestamp_to = int(current_date)
@@ -138,7 +138,7 @@ class CalendarScraper:
         response.raise_for_status()
 
         # Parse the result into a list
-        dividend_events: list[DividendEvent] = []
+        dividend_events: List[DividendEvent] = []
 
         for event in response.json()["data"]:
             event_data = event.get("d")
@@ -165,12 +165,13 @@ class CalendarScraper:
 
         return dividend_events
 
+
     def scrape_earnings(
         self,
-        timestamp_from: int | None,
-        timestamp_to: int | None,
-        markets: list[str] | None,
-    ):
+        timestamp_from: Optional[int] = None,
+        timestamp_to: Optional[int] = None,
+        markets: Optional[List[str]] = None,
+    ) -> List[EarningsEvent]:
         """
         Scrapes earnings events from the TradingView event calendar.
 
@@ -188,12 +189,12 @@ class CalendarScraper:
         url = "https://scanner.tradingview.com/global/scan?label-product=calendar-earnings"
 
         # By default the timestamps mimick the timestamps used in the web requests
-        if timestamp_from == None:
+        if timestamp_from is None:
             current_date = datetime.datetime.now().timestamp()
             current_date = current_date - (current_date % 86400) - (3 * 86400)
             timestamp_from = int(current_date)
 
-        if timestamp_to == None:
+        if timestamp_to is None:
             current_date = datetime.datetime.now().timestamp()
             current_date = current_date - (current_date % 86400) + (3 * 86400) + 86399
             timestamp_to = int(current_date)
@@ -240,7 +241,7 @@ class CalendarScraper:
         response.raise_for_status()
 
         # Parse the result into a list
-        earnings_events: list[EarningsEvent] = []
+        earnings_events: List[EarningsEvent] = []
 
         for event in response.json()["data"]:
             event_data = event.get("d")

--- a/tradingview_scraper/symbols/cal.py
+++ b/tradingview_scraper/symbols/cal.py
@@ -1,0 +1,277 @@
+from typing import TypedDict
+import requests, datetime, json
+
+from tradingview_scraper.symbols.utils import (
+    save_csv_file,
+    save_json_file,
+    generate_user_agent,
+)
+
+
+class DividendEvent(TypedDict):
+    full_symbol: str
+    dividend_ex_date_recent: int
+    dividend_ex_date_upcoming: int | None
+    logoid: str
+    name: str
+    description: str
+    dividends_yield: float
+    dividend_payment_date_recent: int
+    dividend_payment_date_upcoming: int | None
+    dividend_amount_recent: float
+    dividend_amount_upcoming: float | None
+    fundamental_currency_code: str
+    market: str
+
+
+class EarningsEvent(TypedDict):
+    full_symbol: str
+    earnings_release_next_date: int
+    logoid: str
+    name: str
+    description: str
+    earnings_per_share_fq: float | None
+    earnings_per_share_forecast_next_fq: float | None
+    eps_surprise_fq: float | None
+    eps_surprise_percent_fq: float | None
+    revenue_fq: float | None
+    revenue_forecast_next_fq: float | None
+    market_cap_basic: float
+    earnings_release_time: int
+    earnings_release_next_time: int
+    earnings_per_share_forecast_fq: float | None
+    revenue_forecast_fq: float | None
+    fundamental_currency_code: str
+    market: str
+    earnings_publication_type_fq: int
+    earnings_publication_type_next_fq: int
+    revenue_surprise_fq: float | None
+    revenue_surprise_percent_fq: float | None
+
+
+class CalendarScraper:
+    """
+    A class used to scrape dividend and earnings events from the TradingView event calendar.
+
+    Parameters:
+        export_result (bool): Optional. A flag indicating whether to export the scraped data to a file. Defaults to False.
+        export_type (str): Optional. The type of file to export the data to. Can be 'json' or 'csv'. Defaults to 'json'.
+    """
+
+    def __init__(self, export_result: bool = False, export_type: str = "json"):
+        self.export_result: bool = export_result
+        self.export_type: str = export_type
+        self.headers: dict[str, str] = {"User-Agent": generate_user_agent()}
+
+    def _export(
+        self, data, symbol: str | None = None, data_category: str | None = None
+    ):
+        if self.export_result:
+            if self.export_type == "json":
+                save_json_file(data, symbol, data_category)
+            elif self.export_type == "csv":
+                save_csv_file(data, symbol, data_category)
+
+    def scrape_dividends(
+        self,
+        timestamp_from: int | None,
+        timestamp_to: int | None,
+        markets: list[str] | None,
+    ) -> list[DividendEvent]:
+        """
+        Scrapes dividends events from the TradingView event calendar.
+
+        Args:
+            timestamp_from (int): Optional. The start timestamp for the range of dividends to scrape.
+            timestamp_to (int): Optional. The end timestamp for the range of dividends to scrape.
+            markets (list): Optional. A list of market names to scrape the events from. Example: ["america","argentina","australia","belgium","brazil","canada","china", ...]
+
+        Returns:
+            list[DividendEvent]: A typed dictionary containing the scraped event data.
+
+        Raises:
+            requests.HTTPError: If the HTTP request to fetch the article fails.
+        """
+        url = "https://scanner.tradingview.com/global/scan?label-product=calendar-dividends"
+
+        # By default the timestamps mimick the timestamps used in the web requests
+        if timestamp_from == None:
+            current_date = datetime.datetime.now().timestamp()
+            current_date = current_date - (current_date % 86400) - (3 * 86400)
+            timestamp_from = int(current_date)
+
+        if timestamp_to == None:
+            current_date = datetime.datetime.now().timestamp()
+            current_date = current_date - (current_date % 86400) + (3 * 86400) + 86399
+            timestamp_to = int(current_date)
+
+        payload = {
+            "columns": [
+                "dividend_ex_date_recent",
+                "dividend_ex_date_upcoming",
+                "logoid",
+                "name",
+                "description",
+                "dividends_yield",
+                "dividend_payment_date_recent",
+                "dividend_payment_date_upcoming",
+                "dividend_amount_recent",
+                "dividend_amount_upcoming",
+                "fundamental_currency_code",
+                "market",
+            ],
+            "filter": [
+                {
+                    "left": "dividend_ex_date_recent,dividend_ex_date_upcoming",
+                    "operation": "in_range",
+                    "right": [timestamp_from, timestamp_to],
+                }
+            ],
+            "ignore_unknown_fields": False,
+            "options": {"lang": "en"},
+        }
+
+        if markets:
+            payload["markets"] = markets
+
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload))
+        response.raise_for_status()
+
+        # Parse the result into a list
+        dividend_events: list[DividendEvent] = []
+
+        for event in response.json()["data"]:
+            event_data = event.get("d")
+
+            dividend_event = DividendEvent(
+                full_symbol=event.get("s"),
+                dividend_ex_date_recent=event_data[0],
+                dividend_ex_date_upcoming=event_data[1],
+                logoid=event_data[2],
+                name=event_data[3],
+                description=event_data[4],
+                dividends_yield=event_data[5],
+                dividend_payment_date_recent=event_data[6],
+                dividend_payment_date_upcoming=event_data[7],
+                dividend_amount_recent=event_data[8],
+                dividend_amount_upcoming=event_data[9],
+                fundamental_currency_code=event_data[10],
+                market=event_data[11],
+            )
+            dividend_events.append(dividend_event)
+
+        if self.export_result:
+            self._export(dividend_events, "dividends", "calendar")
+
+        return dividend_events
+
+    def scrape_earnings(
+        self,
+        timestamp_from: int | None,
+        timestamp_to: int | None,
+        markets: list[str] | None,
+    ):
+        """
+        Scrapes earnings events from the TradingView event calendar.
+
+        Args:
+            timestamp_from (int): Optional. The start timestamp for the range of earnings to scrape.
+            timestamp_to (int): Optional. The end timestamp for the range of earnings to scrape.
+            markets (list): Optional. A list of market names to scrape the events from. Example: ["america","argentina","australia","belgium","brazil","canada","china", ...]
+
+        Returns:
+            list[EarningsEvent]: A typed dictionary containing the scraped event data.
+
+        Raises:
+            requests.HTTPError: If the HTTP request to fetch the article fails.
+        """
+        url = "https://scanner.tradingview.com/global/scan?label-product=calendar-earnings"
+
+        # By default the timestamps mimick the timestamps used in the web requests
+        if timestamp_from == None:
+            current_date = datetime.datetime.now().timestamp()
+            current_date = current_date - (current_date % 86400) - (3 * 86400)
+            timestamp_from = int(current_date)
+
+        if timestamp_to == None:
+            current_date = datetime.datetime.now().timestamp()
+            current_date = current_date - (current_date % 86400) + (3 * 86400) + 86399
+            timestamp_to = int(current_date)
+
+        payload = {
+            "filter": [
+                {
+                    "left": "earnings_release_date,earnings_release_next_date",
+                    "operation": "in_range",
+                    "right": [timestamp_from, timestamp_to],
+                }
+            ],
+            "columns": [
+                "earnings_release_next_date",
+                "earnings_release_date",
+                "logoid",
+                "name",
+                "description",
+                "earnings_per_share_fq",
+                "earnings_per_share_forecast_next_fq",
+                "eps_surprise_fq",
+                "eps_surprise_percent_fq",
+                "revenue_fq",
+                "revenue_forecast_next_fq",
+                "market_cap_basic",
+                "earnings_release_time",
+                "earnings_release_next_time",
+                "earnings_per_share_forecast_fq",
+                "revenue_forecast_fq",
+                "fundamental_currency_code",
+                "market",
+                "earnings_publication_type_fq",
+                "earnings_publication_type_next_fq",
+                "revenue_surprise_fq",
+                "revenue_surprise_percent_fq",
+            ],
+            "options": {"lang": "en"},
+        }
+
+        if markets:
+            payload["markets"] = markets
+
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload))
+        response.raise_for_status()
+
+        # Parse the result into a list
+        earnings_events: list[EarningsEvent] = []
+
+        for event in response.json()["data"]:
+            event_data = event.get("d")
+
+            earnings_event = EarningsEvent(
+                full_symbol=event.get("s"),
+                earnings_release_next_date=event_data[0],
+                logoid=event_data[1],
+                name=event_data[2],
+                description=event_data[3],
+                earnings_per_share_fq=event_data[4],
+                earnings_per_share_forecast_next_fq=event_data[5],
+                eps_surprise_fq=event_data[6],
+                eps_surprise_percent_fq=event_data[7],
+                revenue_fq=event_data[8],
+                revenue_forecast_next_fq=event_data[9],
+                market_cap_basic=event_data[10],
+                earnings_release_time=event_data[11],
+                earnings_release_next_time=event_data[12],
+                earnings_per_share_forecast_fq=event_data[13],
+                revenue_forecast_fq=event_data[14],
+                fundamental_currency_code=event_data[15],
+                market=event_data[16],
+                earnings_publication_type_fq=event_data[17],
+                earnings_publication_type_next_fq=event_data[18],
+                revenue_surprise_fq=event_data[19],
+                revenue_surprise_percent_fq=event_data[20],
+            )
+            earnings_events.append(earnings_event)
+
+        if self.export_result:
+            self._export(earnings_events, "earnings", "calendar")
+
+        return earnings_events


### PR DESCRIPTION
This PR adds a class for scraping the Calendar events. Supports scraping dividend & earnings data.

This feature was requested in: https://github.com/mnwato/tradingview-scraper/issues/18

