### PR TITLE
Make the release workflow only run on main repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    if: github.repository == 'mnwato/tradingview-scraper'
 
     steps:
     - uses: actions/checkout@v4
@@ -32,7 +33,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: github.repository == 'mnwato/tradingview-scraper' && startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
@@ -55,6 +56,7 @@ jobs:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
+    if: github.repository == 'mnwato/tradingview-scraper'
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
@@ -96,6 +98,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.repository == 'mnwato/tradingview-scraper'
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes the release workflow only run on the main repository.